### PR TITLE
Add timer 

### DIFF
--- a/MediaCoder.ahk
+++ b/MediaCoder.ahk
@@ -5,6 +5,7 @@ Loop {
 	WinGetText, WindowText
 	RegExMatch(WindowText, "math:\s(\d+)\s*([-\+])\s*(\d+)", Expression)
 	
+	sleep, 2000 ;
 	if(Expression2 = "-")
 		Result := Expression1 - Expression3
 	else if (Expression2 = "+")
@@ -16,5 +17,6 @@ Loop {
 	}
 	
 	ControlSetText, Edit2, %Result%
+	sleep, 2000 ;
 	ControlClick, Button2
 }


### PR DESCRIPTION
If MediaCoder does not notice a delay, the popups continue infinitely. 

Sleeping before and after entering the answer worked for me.